### PR TITLE
Fix frame prefixes

### DIFF
--- a/vorc_gazebo/config/rviz_cora.rviz
+++ b/vorc_gazebo/config/rviz_cora.rviz
@@ -1,14 +1,16 @@
 Panels:
   - Class: rviz/Displays
-    Help Height: 78
+    Help Height: 138
     Name: Displays
     Property Tree Widget:
       Expanded:
         - /Global Options1
         - /Status1
         - /PointCloud21
+        - /RobotModel1
+        - /RobotModel1/Status1
       Splitter Ratio: 0.5
-    Tree Height: 249
+    Tree Height: 666
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -107,6 +109,117 @@ Visualization Manager:
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
+    - Alpha: 1
+      Class: rviz/RobotModel
+      Collision Enabled: false
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        dummy_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_left_camera_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_left_camera_link_optical:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        front_left_camera_post_arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_left_camera_post_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_lidar_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_lidar_post_arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_lidar_post_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_right_camera_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_right_camera_link_optical:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        front_right_camera_post_arm_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        front_right_camera_post_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        gps_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        imu_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        left_engine_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        left_propeller_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        pinger:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        right_engine_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+        right_propeller_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+      Name: RobotModel
+      Robot Description: cora/robot_description
+      TF Prefix: cora
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -158,12 +271,12 @@ Visualization Manager:
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 991
+  Height: 2012
   Hide Left Dock: false
-  Hide Right Dock: false
+  Hide Right Dock: true
   Image:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000017000000345fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b00000182000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000001c3000000db0000001600fffffffb0000000a0049006d00610067006501000002a4000000dc0000001600ffffff000000010000010f00000345fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003b00000345000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000005200000003efc0100000002fb0000000800540069006d00650100000000000005200000024400fffffffb0000000800540069006d00650100000000000004500000000000000000000002950000034500000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001dc000006eefc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b000000ab00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000069000003880000017800fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000003fd000001a60000002100fffffffb0000000a0049006d00610067006501000005af000001a80000002100ffffff000000010000014f000006eefc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000069000006ee0000012300fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000052000000050fc0100000002fb0000000800540069006d00650100000000000005200000045300fffffffb0000000800540069006d0065010000000000000450000000000000000000000338000006ee00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -171,7 +284,7 @@ Window Geometry:
   Tool Properties:
     collapsed: false
   Views:
-    collapsed: false
+    collapsed: true
   Width: 1312
-  X: 2666
-  Y: 242
+  X: 2528
+  Y: 55

--- a/vorc_gazebo/config/rviz_cora.rviz
+++ b/vorc_gazebo/config/rviz_cora.rviz
@@ -6,11 +6,9 @@ Panels:
       Expanded:
         - /Global Options1
         - /Status1
-        - /PointCloud21
         - /RobotModel1
-        - /RobotModel1/Status1
       Splitter Ratio: 0.5
-    Tree Height: 666
+    Tree Height: 854
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -29,7 +27,7 @@ Panels:
     Experimental: false
     Name: Time
     SyncMode: 0
-    SyncSource: Image
+    SyncSource: Left Image
 Preferences:
   PromptSaveOnExit: true
 Toolbars:
@@ -61,7 +59,7 @@ Visualization Manager:
       Max Value: 1
       Median window: 5
       Min Value: 0
-      Name: Image
+      Name: Left Image
       Normalize Range: true
       Queue Size: 2
       Transport Hint: raw
@@ -73,7 +71,7 @@ Visualization Manager:
       Max Value: 1
       Median window: 5
       Min Value: 0
-      Name: Image
+      Name: Right Image
       Normalize Range: true
       Queue Size: 2
       Transport Hint: raw
@@ -220,6 +218,95 @@ Visualization Manager:
       Update Interval: 0
       Value: true
       Visual Enabled: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        cora/base_link:
+          Value: true
+        cora/dummy_link:
+          Value: true
+        cora/front_left_camera_link:
+          Value: true
+        cora/front_left_camera_link_optical:
+          Value: true
+        cora/front_left_camera_post_arm_link:
+          Value: true
+        cora/front_left_camera_post_link:
+          Value: true
+        cora/front_lidar_link:
+          Value: true
+        cora/front_lidar_post_arm_link:
+          Value: true
+        cora/front_lidar_post_link:
+          Value: true
+        cora/front_right_camera_link:
+          Value: true
+        cora/front_right_camera_link_optical:
+          Value: true
+        cora/front_right_camera_post_arm_link:
+          Value: true
+        cora/front_right_camera_post_link:
+          Value: true
+        cora/gps_link:
+          Value: true
+        cora/imu_link:
+          Value: true
+        cora/left_engine_link:
+          Value: true
+        cora/left_propeller_link:
+          Value: true
+        cora/odom:
+          Value: true
+        cora/pinger:
+          Value: true
+        cora/right_engine_link:
+          Value: true
+        cora/right_propeller_link:
+          Value: true
+        utm:
+          Value: true
+      Marker Scale: 3
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        cora/odom:
+          cora/base_link:
+            cora/dummy_link:
+              {}
+            cora/front_left_camera_post_link:
+              cora/front_left_camera_post_arm_link:
+                cora/front_left_camera_link:
+                  cora/front_left_camera_link_optical:
+                    {}
+            cora/front_lidar_post_link:
+              cora/front_lidar_post_arm_link:
+                cora/front_lidar_link:
+                  {}
+            cora/front_right_camera_post_link:
+              cora/front_right_camera_post_arm_link:
+                cora/front_right_camera_link:
+                  cora/front_right_camera_link_optical:
+                    {}
+            cora/gps_link:
+              {}
+            cora/imu_link:
+              {}
+            cora/left_engine_link:
+              cora/left_propeller_link:
+                {}
+            cora/pinger:
+              {}
+            cora/right_engine_link:
+              cora/right_propeller_link:
+                {}
+          utm:
+            {}
+      Update Interval: 0
+      Value: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -255,9 +342,9 @@ Visualization Manager:
         Swap Stereo Eyes: false
         Value: false
       Focal Point:
-        X: -0.8610678911209106
-        Y: 0.523205578327179
-        Z: 0.27425241470336914
+        X: -0.8431905508041382
+        Y: -0.5899252891540527
+        Z: 1.12267005443573
       Focal Shape Fixed Size: true
       Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
@@ -274,9 +361,11 @@ Window Geometry:
   Height: 2012
   Hide Left Dock: false
   Hide Right Dock: true
-  Image:
+  Left Image:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000001dc000006eefc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b000000ab00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000069000003880000017800fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d00610067006501000003fd000001a60000002100fffffffb0000000a0049006d00610067006501000005af000001a80000002100ffffff000000010000014f000006eefc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000069000006ee0000012300fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000052000000050fc0100000002fb0000000800540069006d00650100000000000005200000045300fffffffb0000000800540069006d0065010000000000000450000000000000000000000338000006ee00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd0000000400000000000001dc000006eefc020000000cfb0000001200530065006c0065006300740069006f006e00000001e10000009b000000ab00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000069000004440000017800fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000a0049006d006100670065010000029a000001a60000000000000000fb0000000a0049006d006100670065010000044c000001a80000000000000000fb00000014004c00650066007400200049006d00610067006501000004b9000001480000002100fffffffb000000160052006900670068007400200049006d006100670065010000060d0000014a0000002100ffffff000000010000014f000006eefc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000069000006ee0000012300fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000052000000050fc0100000002fb0000000800540069006d00650100000000000005200000045300fffffffb0000000800540069006d0065010000000000000450000000000000000000000338000006ee00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Right Image:
+    collapsed: false
   Selection:
     collapsed: false
   Time:

--- a/vorc_gazebo/launch/localization_example.launch
+++ b/vorc_gazebo/launch/localization_example.launch
@@ -17,12 +17,12 @@
     <param name="sensor_timeout" value="2.0"/>
     <param name="two_d_mode" value="false"/>
     <param name="map_frame" value="map"/>
-    <param name="odom_frame" value="wamv/odom"/>
-    <param name="base_link_frame" value="wamv/base_link"/>
-    <param name="world_frame" value="wamv/odom"/>
+    <param name="odom_frame" value="cora/odom"/>
+    <param name="base_link_frame" value="cora/base_link"/>
+    <param name="world_frame" value="cora/odom"/>
     <param name="publish_tf" value="true"/>
     <param name="frequency" value="60"/>
-    <param name="imu0" value="/wamv/sensors/imu/imu/data"/>
+    <param name="imu0" value="/cora/sensors/imu/imu/data"/>
     <!-- IMU measures orientation, angular velocity, and linear acceleration -->
     <rosparam param="imu0_config">[false, false, false,
                                    true,  true,  true,
@@ -47,7 +47,7 @@
   <!-- Produces local odometry from GPS to be used in Kalman filter -->
   <node ns="cora/robot_localization" pkg="robot_localization" type="navsat_transform_node"
         name="navsat_transform_node" respawn="true" output="screen">
-    <param name="tf_prefix" value="wamv" />
+    <param name="tf_prefix" value="cora" />
     <param name="frequency" value="60"/>
     <param name="magnetic_declination_radians" value="0"/>
     <param name="broadcast_utm_transform" value="true"/>


### PR DESCRIPTION
Fixes #8 

The errors in the display of RobotModel in RViz were fixed with TF Prefix field set to `cora`. RViz config has been updated with this setting.

The `utm` and `wamv/odom` errors disappeared after replacing the instances of `wamv` in `localization_example.launch` with `cora`. (Sorry I rushed a bit in my review of that PR and didn't see these.)

This is the default RViz display now. RobotModel and TF show up correctly wrt global fixed frame `cora/base_link`, and no errors:
![Screenshot from 2020-10-09 23-33-52](https://user-images.githubusercontent.com/7608908/95644907-09223980-0a88-11eb-9bc1-a55d5124dca8.png)

Don't worry about the sensors not being visible - they need to be lifted +1 in z after the hydroparameters needed to lift the robot body by 1. The sensors are lifted in #6.

Test with:
```
$ roslaunch vorc_gazebo marina.launch 
$ roslaunch vorc_gazebo localization_example.launch 
$ roslaunch vorc_gazebo rviz.launch 
```
The only thing is that I get a bunch of timestamp warnings printed from `localization_example.launch`:
```
[ WARN] [1602299727.265646216, 6.738000000]: Transform from cora/gps_link to cora/base_link was unavailable for the time requested. Using latest instead.
[ WARN] [1602299728.661596365, 8.133000000]: Transform from cora/imu_link to cora/base_link was unavailable for the time requested. Using latest instead.
```
I think that is normal, because I get them when I run the VRX counterparts too:
```
$ roslaunch vrx_gazebo vrx.launch
$ roslaunch wamv_gazebo rviz_example.launch 
$ roslaunch wamv_gazebo localization_example.launch 
[...]
[ WARN] [1602299989.014063719, 30.687000000]: Transform from wamv/gps_wamv_link to wamv/base_link was unavailable for the time requested. Using latest instead.
[ WARN] [1602299990.195272106, 31.867000000]: Transform from wamv/imu_wamv_link to wamv/base_link was unavailable for the time requested. Using latest instead.
```