### PR TITLE
Changed GPS coords to reflect marina location

### DIFF
--- a/cora_description/urdf/cora.xacro
+++ b/cora_description/urdf/cora.xacro
@@ -60,7 +60,7 @@
   <xacro:wamv_camera name="front_left_camera"  x="-0.61" y="0.2"  z="4.7" post_z_from="4.6" P="${radians(15)}" />
   <xacro:wamv_camera name="front_right_camera" x="-0.61" y="-0.2" z="4.7" post_z_from="4.6" P="${radians(15)}" />
   <xacro:lidar name="front_lidar" type="16_beam" x="-0.595" z="5" P="${radians(8)}" post_z_from="4.6"/>
-  <xacro:wamv_gps name="gps" x="-1.0" z="4.6" />
+  <xacro:wamv_gps name="gps" x="-1.0" z="4.6" lat="44.091722" lon="9.823564"/>
   <xacro:wamv_imu name="imu" y="-0.2" z="1.0" />
   <xacro:wamv_pinger name="pinger" frameId="cora/pinger" />
 

--- a/cora_description/urdf/macros.xacro
+++ b/cora_description/urdf/macros.xacro
@@ -5,7 +5,8 @@
 
   <!-- Include sensor macros -->
   <xacro:include filename="$(find wamv_gazebo)/urdf/sensors/wamv_camera.xacro" />
-  <xacro:include filename="$(find wamv_gazebo)/urdf/sensors/wamv_gps.xacro" />
+  <!-- Modified for marina world -->
+  <xacro:include filename="$(find cora_description)/urdf/sensors/wamv_gps.xacro" />
   <xacro:include filename="$(find wamv_gazebo)/urdf/sensors/wamv_imu.xacro" />
   <xacro:include filename="$(find wamv_gazebo)/urdf/sensors/wamv_planar_lidar.xacro" />
   <xacro:include filename="$(find wamv_gazebo)/urdf/sensors/wamv_3d_lidar.xacro" />

--- a/cora_description/urdf/sensors/wamv_gps.xacro
+++ b/cora_description/urdf/sensors/wamv_gps.xacro
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+  <xacro:macro name="wamv_gps" params="name:=gps x:=0.3 y:=0 z:=1.3 R:=0 P:=0 Y:=0">
+    <link name="${name}_link">
+      <visual name="${name}_visual">
+        <geometry>
+          <mesh filename="package://wamv_gazebo/models/gps/mesh/gps.dae"/>
+        </geometry>
+      </visual>
+      <collision name="${name}_collision_base">
+        <origin xyz="0 0 0.025" rpy="0 0 0" />
+        <geometry>
+          <cylinder length="0.05" radius="0.015" />
+        </geometry>
+      </collision>
+      <collision name="${name}_collision_antenna">
+        <origin xyz="0 0 0.11" rpy="0 0 0" />
+        <geometry>
+          <cylinder length="0.1" radius="0.15" />
+        </geometry>
+      </collision>
+      <inertial>
+        <mass value="1"/>
+        <inertia ixx="0.006458" ixy="0.0" ixz="0.0" iyy="0.006458" iyz="0.0" izz="0.01125"/>
+      </inertial>
+    </link>
+    <joint name="${name}_joint" type="revolute">
+      <axis xyz="0 0 1"/>
+      <limit effort="1000.0" lower="0.0" upper="0" velocity="0"/>
+      <origin xyz="${x} ${y} ${z}" rpy="${R} ${P} ${Y}" />
+      <parent link="base_link" />
+      <child link="${name}_link" />
+    </joint>
+    <gazebo>
+      <plugin name="gps_plugin_${name}" filename="libhector_gazebo_ros_gps.so">
+        <updateRate>15.0</updateRate>
+        <alwaysOn>true</alwaysOn>
+        <bodyName>${name}_link</bodyName>
+        <!-- Manually prepend namespace to tf frame. -->
+        <frameId>${namespace}/${name}_link</frameId>
+        <topicName>${namespace}/${sensor_namespace}gps/gps/fix</topicName>
+        <!-- Note that the hector_gazebo_ros_gps plugin uses NWU coordinates
+             for reporting velocities.  This may cause problems if localization
+             requires velocity in ENU.  
+             See Issue #64 in VRX project for details
+             https://bitbucket.org/osrf/vrx/issues/64 -->
+        <velocityTopicName>${namespace}/${sensor_namespace}gps/gps/fix_velocity</velocityTopicName>
+        <!-- Location of origin of Gazebo Sand Island map -->
+        <!-- via La Spezia, Italy -->
+        <referenceLatitude>44.091722</referenceLatitude>
+        <referenceLongitude>9.823564</referenceLongitude>
+        <referenceAltitude>0</referenceAltitude>
+        <referenceHeading>90</referenceHeading>
+        <offset>0.0 0.0 0.0</offset>
+        <drift>0.0 0.0 0.0</drift>
+        <gaussianNoise>0 0 0</gaussianNoise>
+        <velocityOffset>0.0 0.0 0.0</velocityOffset>
+        <velocityDrift>0.0 0.0 0.0</velocityDrift>
+        <velocityGaussianNoise>0.0 0.0 0.0</velocityGaussianNoise>
+      </plugin>
+    </gazebo>
+  </xacro:macro>
+</robot>
+
+

--- a/vorc_gazebo/worlds/marina.xacro
+++ b/vorc_gazebo/worlds/marina.xacro
@@ -15,8 +15,8 @@
     <spherical_coordinates>
       <surface_model>EARTH_WGS84</surface_model>
       <world_frame_orientation>ENU</world_frame_orientation>
-      <latitude_deg>21.30996</latitude_deg>
-      <longitude_deg>-157.8901</longitude_deg>
+      <latitude_deg>44.091722</latitude_deg>
+      <longitude_deg>9.823564</longitude_deg>
       <elevation>0.0</elevation>
       <!-- For legacy gazebo reasons, need to rotate -->
       <!--<heading_deg>180</heading_deg>-->

--- a/vorc_gazebo/worlds/station_keeping.world.xacro
+++ b/vorc_gazebo/worlds/station_keeping.world.xacro
@@ -31,7 +31,7 @@
       <task_info_topic>/vorc/task/info</task_info_topic>
       <contact_debug_topic>/vorc/debug/contact</contact_debug_topic>
       <!-- Goal as Latitude, Longitude, Yaw -->
-      <goal_pose>21.30671 -157.88971 0.0 </goal_pose>
+      <goal_pose>44.088427 9.8238729 0.0 </goal_pose>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>

--- a/vorc_gazebo/worlds/wayfinding.world.xacro
+++ b/vorc_gazebo/worlds/wayfinding.world.xacro
@@ -34,15 +34,15 @@
       <waypoints>
         <!-- Approx. starting point of wamv -->
         <waypoint>
-          <pose>21.3065958113 -157.890015439 1.21756121843</pose>
+          <pose>44.0883705386 9.82367673319 1.21756121843</pose>
         </waypoint>
         <!-- A waypoint -->
         <waypoint>
-          <pose>21.30996 -157.8901 1.0</pose>
+          <pose>44.0916341743 9.82668230867 1.0</pose>
         </waypoint>
         <!-- Another waypoint -->
         <waypoint>
-          <pose>21.3101390111 -157.88657555 1.0</pose>
+          <pose>44.0913208285 9.82350874434 1.0</pose>
         </waypoint>
       </waypoints>
       <initial_state_duration>10</initial_state_duration>


### PR DESCRIPTION
Changed GPS coordinates to reflect location, La Spezia, Italy as per issue #23 
Related to PR osrf/vrx#225

```
 <spherical_coordinates>
      <surface_model>EARTH_WGS84</surface_model>
      <world_frame_orientation>ENU</world_frame_orientation>
      <latitude_deg>44.091722</latitude_deg>
      <longitude_deg>9.823564</longitude_deg>
      <elevation>0.0</elevation>
      <!-- For legacy gazebo reasons, need to rotate -->
      <!--<heading_deg>180</heading_deg>-->
    </spherical_coordinates>
```

Modified goals in station_keeping task
```
<!-- Goal as Latitude, Longitude, Yaw -->
      <goal_pose>44.088427 9.8238729 0.0 </goal_pose>
```

Modified goals in wayfinding task
```
<!-- Goal as Latitude, Longitude, Yaw -->
      <waypoints>
        <!-- Approx. starting point of wamv -->
        <waypoint>
          <pose>44.0883705386 9.82367673319 1.21756121843</pose>
        </waypoint>
        <!-- A waypoint -->
        <waypoint>
          <pose>44.0916341743 9.82668230867 1.0</pose>
        </waypoint>
        <!-- Another waypoint -->
        <waypoint>
          <pose>44.0913208285 9.82350874434 1.0</pose>
        </waypoint>
      </waypoints>
```

Added `wamv_gps.xacro` to new directory, `cora_description/urdf/sensors`, to modify robot GPS coords and preserve VRX wamv coords.

Tested all tasks again, appear to operate as expected.