### PR TITLE
Fix Gymkhana topic names

### DIFF
--- a/vorc_gazebo/worlds/gymkhana.world.xacro
+++ b/vorc_gazebo/worlds/gymkhana.world.xacro
@@ -43,8 +43,8 @@
             filename="libgymkhana_scoring_plugin.so">
       <vehicle>cora</vehicle>
       <task_name>gymkhana</task_name>
-      <task_info_topic>/vorc/gymkhana/task/info</task_info_topic>
-      <contact_debug_topic>/vorc/gymkhana/debug/contact</contact_debug_topic>
+      <task_info_topic>/vorc/task/info</task_info_topic>
+      <contact_debug_topic>/vorc/debug/contact</contact_debug_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>

--- a/vorc_gazebo/worlds/xacros/gymkhana.xacro
+++ b/vorc_gazebo/worlds/xacros/gymkhana.xacro
@@ -29,8 +29,8 @@
             filename="libgymkhana_scoring_plugin.so">
       <vehicle>${namespace}</vehicle>
       <task_name>gymkhana</task_name>
-      <task_info_topic>/${competition}/gymkhana/task/info</task_info_topic>
-      <contact_debug_topic>/${competition}/gymkhana/debug/contact</contact_debug_topic>
+      <task_info_topic>/${competition}/task/info</task_info_topic>
+      <contact_debug_topic>/${competition}/debug/contact</contact_debug_topic>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>${running_duration}</running_state_duration>

--- a/vorc_gazebo/worlds/xacros/gymkhana.xacro
+++ b/vorc_gazebo/worlds/xacros/gymkhana.xacro
@@ -2,7 +2,7 @@
 <world xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="gymkhana" params="
     namespace:=cora competition:=vorc
-    nav_name='gymkhana_nav' nav_uri:=short_navigation_course0
+    nav_name='short_navigation_course_0' nav_uri:=short_navigation_course0
     nav_x:=60 nav_y:=-362 nav_z:=0 nav_R:=0 nav_P:=0 nav_Y:=3.55
     obs_name='gymkhana_obs' obs_uri:=obstacle_course
     obs_x:=140 obs_y:=-282 obs_z:=0 obs_R:=0 obs_P:=0 obs_Y:=3.55


### PR DESCRIPTION
Fix gymkhana task topic names. The top-level scoring plugin topic names had one level too many. This led to the Docker evaluation listening to a different topic from the one that the team solution publishes, causing the boat to not move.

Wiki has been updated with the new topic name.