### PR TITLE
WIP: 1) Compatible with ROS Noetic, 2) Cleanup

### DIFF
--- a/cora_description/CMakeLists.txt
+++ b/cora_description/CMakeLists.txt
@@ -18,7 +18,7 @@ catkin_package(
 
 xacro_add_files(
   urdf/cora.urdf.xacro
-    INORDER INSTALL DESTINATION urdf
+    INSTALL DESTINATION urdf
 )
 
 install(DIRECTORY models/

--- a/vorc_gazebo/CMakeLists.txt
+++ b/vorc_gazebo/CMakeLists.txt
@@ -45,7 +45,7 @@ xacro_add_files(
   worlds/station_keeping.world.xacro
   worlds/wayfinding.world.xacro
   worlds/gymkhana.world.xacro
-  INORDER INSTALL DESTINATION worlds
+  INSTALL DESTINATION worlds
 )
 
 install(DIRECTORY worlds/

--- a/vorc_gazebo/package.xml
+++ b/vorc_gazebo/package.xml
@@ -12,8 +12,14 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>cora_description</depend>
   <depend>gazebo_dev</depend>
   <depend version_gte="2.5.17">gazebo_ros</depend>
+  <depend>joint_state_publisher</depend>
+  <depend>robot_localization</depend>
+  <depend>robot_state_publisher</depend>
+  <depend>rospy</depend>
+  <depend>rviz</depend>
   <depend>vrx_gazebo</depend>
   <depend>wamv_gazebo</depend>
   <depend>wave_gazebo</depend>


### PR DESCRIPTION
NOTE: **Do NOT merge** into `master` unless the default ROS version is updated to ROS Noetic or newer.

# Problem
As the [environment requiremet of vorc 2020](https://github.com/osrf/vorc/wiki/Installation-on-Host) is ROS Melodic, the pkg does not build on a newer ROS environment, e.g. Noetic.

```
# colcon build
:
CMake Error at /opt/ros/noetic/share/xacro/cmake/xacro-extras.cmake:49 (message):
  no <output> specified for: INORDER
Call Stack (most recent call first):
  /opt/ros/noetic/share/xacro/cmake/xacro-extras.cmake:167 (xacro_add_xacro_file)
  CMakeLists.txt:5 (xacro_add_files)
```  

# Approach
Remove the obsolete option from `xacro`'s cmake macro.

# Changes added in this PR
- Fix for the aforementioned xacro issue.
- Add missing dependency that [roscompile](http://wiki.ros.org/roscompile) revealed (which has nothing to do with Noetic conversion).