### PR TITLE
Fine tune the GPS reference point so that real world maps are better aligned

### DIFF
--- a/cora_description/urdf/cora.xacro
+++ b/cora_description/urdf/cora.xacro
@@ -60,7 +60,7 @@
   <xacro:wamv_camera name="front_left_camera"  x="-0.61" y="0.2"  z="4.7" post_z_from="4.6" P="${radians(15)}" />
   <xacro:wamv_camera name="front_right_camera" x="-0.61" y="-0.2" z="4.7" post_z_from="4.6" P="${radians(15)}" />
   <xacro:lidar name="front_lidar" type="16_beam" x="-0.595" z="5" P="${radians(8)}" post_z_from="4.6"/>
-  <xacro:wamv_gps name="gps" x="-1.0" z="4.6" lat="44.091722" lon="9.823564" update_rate="20" />
+  <xacro:wamv_gps name="gps" x="-1.0" z="4.6" lat="44.09525149" lon="9.823435727" update_rate="20" />
   <xacro:wamv_imu name="imu" y="-0.2" z="1.0" update_rate="100" />
   <xacro:wamv_pinger name="pinger" frameId="cora/pinger" />
 

--- a/vorc_gazebo/worlds/marina.xacro
+++ b/vorc_gazebo/worlds/marina.xacro
@@ -15,8 +15,8 @@
     <spherical_coordinates>
       <surface_model>EARTH_WGS84</surface_model>
       <world_frame_orientation>ENU</world_frame_orientation>
-      <latitude_deg>44.091722</latitude_deg>
-      <longitude_deg>9.823564</longitude_deg>
+      <latitude_deg>44.09525149</latitude_deg>
+      <longitude_deg>9.823435727</longitude_deg>
       <elevation>0.0</elevation>
       <!-- For legacy gazebo reasons, need to rotate -->
       <!--<heading_deg>180</heading_deg>-->

--- a/vorc_gazebo/worlds/station_keeping.world.xacro
+++ b/vorc_gazebo/worlds/station_keeping.world.xacro
@@ -30,7 +30,7 @@
       <task_info_topic>/vorc/task/info</task_info_topic>
       <contact_debug_topic>/vorc/debug/contact</contact_debug_topic>
       <!-- Goal as Latitude, Longitude, Yaw -->
-      <goal_pose>44.088427 9.8238729 0.0</goal_pose>
+      <goal_pose>44.09195649 9.823744627 0.0</goal_pose>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>

--- a/vorc_gazebo/worlds/wayfinding.world.xacro
+++ b/vorc_gazebo/worlds/wayfinding.world.xacro
@@ -34,15 +34,15 @@
       <waypoints>
         <!-- Approx. starting point of wamv -->
         <waypoint>
-          <pose>44.0883705386 9.82367673319 1.21756121843</pose>
+          <pose>44.09190002 9.82354846 1.21756121843</pose>
         </waypoint>
         <!-- A waypoint -->
         <waypoint>
-          <pose>44.0916341743 9.82668230867 1.0</pose>
+          <pose>44.09516366 9.826554036 1.0</pose>
         </waypoint>
         <!-- Another waypoint -->
         <waypoint>
-          <pose>44.0913208285 9.82350874434 1.0</pose>
+          <pose>44.09485031 9.823380472 1.0</pose>
         </waypoint>
       </waypoints>
       <initial_state_duration>10</initial_state_duration>

--- a/vorc_gazebo/worlds/xacros/marina_minus_scene.xacro
+++ b/vorc_gazebo/worlds/xacros/marina_minus_scene.xacro
@@ -6,8 +6,8 @@
     <spherical_coordinates>
       <surface_model>EARTH_WGS84</surface_model>
       <world_frame_orientation>ENU</world_frame_orientation>
-      <latitude_deg>44.091722</latitude_deg>
-      <longitude_deg>9.823564</longitude_deg>
+      <latitude_deg>44.09525149</latitude_deg>
+      <longitude_deg>9.823435727</longitude_deg>
       <elevation>0.0</elevation>
       <!-- For legacy gazebo reasons, need to rotate -->
       <!--<heading_deg>180</heading_deg>-->


### PR DESCRIPTION
A displacement of about 400 meters was discovered when comparing generated gps coordinates with real world maps. This change adjusts the gps reference point to make real map usable.