### PR TITLE
add new exit flag to gymkhana channel scoring plugin

### DIFF
--- a/vorc_gazebo/worlds/gymkhana.world.xacro
+++ b/vorc_gazebo/worlds/gymkhana.world.xacro
@@ -60,7 +60,7 @@
       <task_name>gymkhana_channel</task_name>
       <task_info_topic>/vorc/gymkhana_channel/task/info</task_info_topic>
       <contact_debug_topic>/vorc/gymkhana_channel/debug/contact</contact_debug_topic>
-      <!-- Per-plugin flag, different from env var VRX_EXIT_ON_COMPLETION -->
+      <!-- Keep Gazebo running after this sub-task is completed -->
       <per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
@@ -102,7 +102,7 @@
       <goal_topic>/vorc/gymkhana_blackbox/goal</goal_topic>
       <task_info_topic>/vorc/gymkhana_blackbox/task/info</task_info_topic>
       <contact_debug_topic>/vorc/gymkhana_blackbox/debug/contact</contact_debug_topic>
-      <!-- Per-plugin flag, different from env var VRX_EXIT_ON_COMPLETION -->
+      <!-- Keep Gazebo running after this sub-task is completed -->
       <per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>
       <!-- Goal as Cartesian coordinates -->
       <goal_pose_cart>116 -278 -5</goal_pose_cart>

--- a/vorc_gazebo/worlds/gymkhana.world.xacro
+++ b/vorc_gazebo/worlds/gymkhana.world.xacro
@@ -48,6 +48,9 @@
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>
+      <!-- Per-plugin flag, different from env var VRX_EXIT_ON_COMPLETION.
+           Respect top-level plugin finished status. -->
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
     </plugin>
 
     <!-- Scoring plugin for buoy channel portion -->
@@ -99,6 +102,8 @@
       <goal_topic>/vorc/gymkhana_blackbox/goal</goal_topic>
       <task_info_topic>/vorc/gymkhana_blackbox/task/info</task_info_topic>
       <contact_debug_topic>/vorc/gymkhana_blackbox/debug/contact</contact_debug_topic>
+      <!-- Per-plugin flag, different from env var VRX_EXIT_ON_COMPLETION -->
+      <per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>
       <!-- Goal as Cartesian coordinates -->
       <goal_pose_cart>116 -278 -5</goal_pose_cart>
       <initial_state_duration>10</initial_state_duration>

--- a/vorc_gazebo/worlds/gymkhana.world.xacro
+++ b/vorc_gazebo/worlds/gymkhana.world.xacro
@@ -57,6 +57,8 @@
       <task_name>gymkhana_channel</task_name>
       <task_info_topic>/vorc/gymkhana_channel/task/info</task_info_topic>
       <contact_debug_topic>/vorc/gymkhana_channel/debug/contact</contact_debug_topic>
+      <!-- Per-plugin flag, different from env var VRX_EXIT_ON_COMPLETION -->
+      <per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>300</running_state_duration>

--- a/vorc_gazebo/worlds/xacros/gymkhana.xacro
+++ b/vorc_gazebo/worlds/xacros/gymkhana.xacro
@@ -46,7 +46,7 @@
       <task_name>gymkhana_channel</task_name>
       <task_info_topic>/${competition}/gymkhana_channel/task/info</task_info_topic>
       <contact_debug_topic>/${competition}/gymkhana_channel/debug/contact</contact_debug_topic>
-      <!-- Keep Gazebo running after channel portion is completed -->
+      <!-- Keep Gazebo running after this sub-task is completed -->
       <per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
@@ -77,7 +77,7 @@
       <goal_topic>/${competition}/gymkhana_blackbox/goal</goal_topic>
       <task_info_topic>/${competition}/gymkhana_blackbox/task/info</task_info_topic>
       <contact_debug_topic>/${competition}/gymkhana_blackbox/debug/contact</contact_debug_topic>
-      <!-- Per-plugin flag, different from env var VRX_EXIT_ON_COMPLETION -->
+      <!-- Keep Gazebo running after this sub-task is completed -->
       <per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>
       <!-- Goal as Cartesian coordinates -->
       <goal_pose_cart>${pinger_x} ${pinger_y} ${pinger_z}</goal_pose_cart>

--- a/vorc_gazebo/worlds/xacros/gymkhana.xacro
+++ b/vorc_gazebo/worlds/xacros/gymkhana.xacro
@@ -31,6 +31,9 @@
       <task_name>gymkhana</task_name>
       <task_info_topic>/${competition}/task/info</task_info_topic>
       <contact_debug_topic>/${competition}/debug/contact</contact_debug_topic>
+      <!-- Per-plugin flag, different from env var VRX_EXIT_ON_COMPLETION.
+           Respect top-level plugin finished status. -->
+      <per_plugin_exit_on_completion>true</per_plugin_exit_on_completion>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>${running_duration}</running_state_duration>
@@ -74,6 +77,8 @@
       <goal_topic>/${competition}/gymkhana_blackbox/goal</goal_topic>
       <task_info_topic>/${competition}/gymkhana_blackbox/task/info</task_info_topic>
       <contact_debug_topic>/${competition}/gymkhana_blackbox/debug/contact</contact_debug_topic>
+      <!-- Per-plugin flag, different from env var VRX_EXIT_ON_COMPLETION -->
+      <per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>
       <!-- Goal as Cartesian coordinates -->
       <goal_pose_cart>${pinger_x} ${pinger_y} ${pinger_z}</goal_pose_cart>
       <initial_state_duration>10</initial_state_duration>

--- a/vorc_gazebo/worlds/xacros/gymkhana.xacro
+++ b/vorc_gazebo/worlds/xacros/gymkhana.xacro
@@ -43,6 +43,8 @@
       <task_name>gymkhana_channel</task_name>
       <task_info_topic>/${competition}/gymkhana_channel/task/info</task_info_topic>
       <contact_debug_topic>/${competition}/gymkhana_channel/debug/contact</contact_debug_topic>
+      <!-- Keep Gazebo running after channel portion is completed -->
+      <per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>
       <initial_state_duration>10</initial_state_duration>
       <ready_state_duration>10</ready_state_duration>
       <running_state_duration>${running_duration}</running_state_duration>


### PR DESCRIPTION
Depends on osrf/vrx#233

Fixes problem:
When boat passes the last set of navigation gates in the gymkhana task, shutdown signal is issued to Gazebo.

A new SDF parameter flag `per_plugin_exit_on_completion` is added.

After these two PRs are merged, we will need to test `vrx-docker` with `ghostship` solution and make sure Gazebo no longer shuts down prematurely.

It's a tiny bit hacky, because now we have two flags for "exiting upon completion." One specified from the environment variables, and another from the SDF parameter. This is because we are chaining multiple scoring plugins for a single task.
They are slightly different in that, the env var is for all the plugins in the current shell, and the SDF parameter is just for one specific plugin.
The dilemma is how to resolve the two when one is true, the other is false.

Currently, I have the env var overwrite the SDF parameter.
Alternatively, we can do an AND or OR, but that might make the `vrx-docker` evaluation more complicated, because the evaluation `run_trial.bash` issues `VRX_EXIT_ON_COMPLETION=true` for all tasks. We currently don't say, issue it on all tasks except gymkhana.
In the overwrite behavior, we can set `VRX_EXIT_ON_COMPLETION=false`, and explicitly specify the SDF parameter flag in each world xacro file. This I think is the cleanest way, though it adds a few lines of SDF.

## To test:
Keep this running in a terminal:
```
rostopic echo /vorc/gymkhana_channel/task/info
```
For all cases below, once the topic `state` field changes to `running`, move the boat by keyboard / mouse / `rostopic pub` straight forward. Observe what happens when it passes the last set of gates.

### Case 1: Original behavior
Comment out the new line `<per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>`.
```
roslaunch vorc_gazebo gymkhana.launch 
```
Expected: When boat passes last gates, gzserver is killed in terminal. gzclient will still be open but no further steps are simulated. No new messages in the rostopic echo above.

### Case 2: Added behavior
Uncomment the new line `<per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>`.
```
roslaunch vorc_gazebo gymkhana.launch 
```
Expected: When boat passes last gates, Gazebo continues running. The `state` field in rostopic echo above changes to `finished`, `score` remains the same for all subsequent messages.

Additionally, I tested by echoing the two tasks in two separate terminals
```
rostopic echo /vorc/gymkhana_blackbox/task/info
rostopic echo /vorc/task/info
```
and saw that when the top-level task "finished" with 0 second left, sub-task blackbox "running" with 1 second left (due to small differences in transport maybe), shutdown was still issued to gazebo, by design.
That verifies that the top-level scoring plugin's time is respected (`<per_plugin_exit_on_completion>` is false for the two sub-tasks, true for the top-level task.)

### Case 3: Original environment variable overwrites added behavior
Uncomment the new line `<per_plugin_exit_on_completion>false</per_plugin_exit_on_completion>`.
```
VRX_EXIT_ON_COMPLETION=true roslaunch vorc_gazebo gymkhana.launch 
```
Expected: Same as case 1.

I hope nothing else is broken, but more thorough tests to find bugs are welcome.