### PR TITLE
Initialize gymkhana score to large number

### DIFF
--- a/vorc_gazebo/src/gymkhana_scoring_plugin.cc
+++ b/vorc_gazebo/src/gymkhana_scoring_plugin.cc
@@ -16,6 +16,7 @@
 */
 
 #include "vorc_gazebo/gymkhana_scoring_plugin.hh"
+#include <limits>
 
 /////////////////////////////////////////////////
 GymkhanaScoringPlugin::GymkhanaScoringPlugin()
@@ -62,6 +63,10 @@ void GymkhanaScoringPlugin::Update()
   if (this->channelCrossed)
   {
     this->ScoringPlugin::SetScore(this->blackboxScore);
+  }
+  else
+  {
+    this->ScoringPlugin::SetScore(std::numeric_limits<double>::max());
   }
 }
 


### PR DESCRIPTION
If gate not crossed, score is max double.