### PR TITLE
Removing INORDER from xacro calls b/c of cmake error

### DIFF
--- a/cora_description/CMakeLists.txt
+++ b/cora_description/CMakeLists.txt
@@ -18,7 +18,7 @@ catkin_package(
 
 xacro_add_files(
   urdf/cora.urdf.xacro
-    INORDER INSTALL DESTINATION urdf
+    INSTALL DESTINATION urdf
 )
 
 install(DIRECTORY models/

--- a/vorc_gazebo/CMakeLists.txt
+++ b/vorc_gazebo/CMakeLists.txt
@@ -45,7 +45,7 @@ xacro_add_files(
   worlds/station_keeping.world.xacro
   worlds/wayfinding.world.xacro
   worlds/gymkhana.world.xacro
-  INORDER INSTALL DESTINATION worlds
+  INSTALL DESTINATION worlds
 )
 
 install(DIRECTORY worlds/


### PR DESCRIPTION
Small change to CMakelists.txt files for Noetic compatibility.  I believe this should be reverse compatible with Melodic.