### PR TITLE
Set duplicate targets to be built for gymkhana

### DIFF
--- a/vorc_gazebo/CMakeLists.txt
+++ b/vorc_gazebo/CMakeLists.txt
@@ -9,6 +9,11 @@ if(POLICY CMP0054)
   cmake_policy(SET CMP0054 OLD)
 endif()
 
+if(POLICY CMP0002)
+    cmake_policy(SET CMP0002 OLD)
+    set(ALLOW_DUPLICATE_CUSTOM_TARGETS)
+endif()
+
 find_package(catkin REQUIRED COMPONENTS
   gazebo_dev
   vrx_gazebo


### PR DESCRIPTION
Was getting the error
```
CMake Deprecation Warning at vorc/vorc_gazebo/CMakeLists.txt:13 (cmake_policy):
  The OLD behavior for policy CMP0002 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.
```
when running `colcon build`. Added to the `CMakeLists.txt` the flag to set duplicate targets, as it appeared that there were multiple targets of gymkhana being built. 