### PR TITLE
Adding namespace for compatibility

### DIFF
--- a/cora_description/urdf/cora.urdf.xacro
+++ b/cora_description/urdf/cora.urdf.xacro
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro" name="cora">
 
-  <link name="base_link">
+  <link name="cora/base_link">
   </link>
 
-  <joint name="dummy_joint" type="fixed">
-    <parent link="base_link"/>
-    <child link="dummy_link"/>
+  <joint name="cora/dummy_joint" type="fixed">
+    <parent link="cora/base_link"/>
+    <child link="cora/dummy_link"/>
     <!-- Adjust the visual/collision to match water height -->
     <origin xyz="0 0 1" rpy="0 0 0"/>
   </joint>
 
-  <link name="dummy_link">
+  <link name="cora/dummy_link">
     <visual>
       <origin xyz="0 0 0" rpy="0 0 0" />
       <geometry>

--- a/cora_description/urdf/cora.xacro
+++ b/cora_description/urdf/cora.xacro
@@ -27,7 +27,7 @@
     <gazebo>
       <link name="cora_external_link"/>
       <joint name="cora_external_pivot_joint" type="universal">
-        <parent>cora::base_link</parent>
+        <parent>cora::cora/base_link</parent>
         <child>cora_external_link</child>
         <axis>
           <xyz>1 0 0</xyz>
@@ -57,10 +57,15 @@
   <xacro:property name="camera_namespace" value="$(arg camera_namespace)" scope="global" />
   <xacro:property name="sensor_namespace" value="$(arg sensor_namespace)" scope="global" />
   <xacro:property name="pinger_namespace" value="$(arg pinger_namespace)" scope="global" />
-  <xacro:wamv_camera name="front_left_camera"  x="-0.61" y="0.2"  z="4.7" post_z_from="4.6" P="${radians(15)}" />
-  <xacro:wamv_camera name="front_right_camera" x="-0.61" y="-0.2" z="4.7" post_z_from="4.6" P="${radians(15)}" />
-  <xacro:lidar name="front_lidar" type="16_beam" x="-0.595" z="5" P="${radians(8)}" post_z_from="4.6"/>
-  <xacro:wamv_gps name="gps" x="-1.0" z="4.6" lat="44.09525149" lon="9.823435727" update_rate="20" />
+  
+  <xacro:wamv_camera name="front_left_camera"  x="-0.61" y="0.2"  z="4.7" 
+  post_z_from="4.6" P="${radians(15)}" />
+  <xacro:wamv_camera name="front_right_camera" x="-0.61" y="-0.2" z="4.7" 
+  post_z_from="4.6" P="${radians(15)}" />
+  <xacro:lidar name="front_lidar" type="16_beam" x="-0.595" z="5" 
+  P="${radians(8)}" post_z_from="4.6"/>
+  <xacro:wamv_gps name="gps" x="-1.0" z="4.6" 
+  	update_rate="20" />
   <xacro:wamv_imu name="imu" y="-0.2" z="1.0" update_rate="100" />
   <xacro:wamv_pinger name="pinger" frameId="cora/pinger" />
 

--- a/cora_description/urdf/cora_dynamics_plugin.xacro
+++ b/cora_description/urdf/cora_dynamics_plugin.xacro
@@ -4,7 +4,7 @@
     <!--Gazebo Plugin for simulating Cora dynamics-->
     <gazebo>
       <plugin name="usv_dynamics_${name}" filename="libusv_gazebo_dynamics_plugin.so">
-        <bodyName>base_link</bodyName>
+        <bodyName>cora/base_link</bodyName>
         <!-- Must be same as the ocean model!-->
         <waterLevel>0</waterLevel>
         <waterDensity>1024.0</waterDensity>

--- a/cora_description/urdf/thrusters.xacro
+++ b/cora_description/urdf/thrusters.xacro
@@ -43,7 +43,7 @@
   <joint name="left_chasis_engine_joint" type="revolute">
     <axis xyz="0 0 1"/>
     <origin rpy="0 0 0" xyz="-6.103 0.911 0.016"/>
-    <parent link="base_link"/>
+    <parent link="cora/base_link"/>
     <child link="left_engine_link"/>
     <limit lower="${-pi}" upper="${pi}" effort="10" velocity="10"/>
   </joint>
@@ -99,7 +99,7 @@
   <joint name="right_chasis_engine_joint" type="revolute">
     <axis xyz="0 0 1"/>
     <origin rpy="0 0 0" xyz="-6.103 -0.911 0.016"/>
-    <parent link="base_link"/>
+    <parent link="cora/base_link"/>
     <child link="right_engine_link"/>
     <limit lower="${-pi}" upper="${pi}" effort="10" velocity="10"/>
   </joint>


### PR DESCRIPTION
When migrating VRX to Noetic (https://github.com/osrf/vrx/pull/247/) we modified the sensor xacro files to use namespace global parameters.  This broke the VORC use of the macros in the CORA vehicle setup.

This PR fixes the issue by including an explicit `cora\` prefix to the link names so that they again are compatible with the VRX sensor macros.

To test...

```
roslaunch vorc_gazebo marina.launch verbose:=true
```