### PR TITLE
Adding note in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# New Development in VRX Project
+
+The functionality in this repository has been moved to the [VRX Project](https://github.com/osrf/vrx) - see [PR#470](https://github.com/osrf/vrx/pull/470).  Any modifications to the project should be done in the VRX repository.
+
 # Virtual Ocean Robotics Challenge (VORC)
 
 This repository is the home to the source code and software documentation for


### PR DESCRIPTION
Moving functionality from VORC -> VRX, so adding a note in this README so folks know that VRX is the most recent.

Once [VRX PR](https://github.com/osrf/vrx/pull/470) is merged, this should be good to go.